### PR TITLE
ci(workflow): re-schedule the addition of stars on mondays

### DIFF
--- a/.github/workflows/star-repositories.yml
+++ b/.github/workflows/star-repositories.yml
@@ -2,7 +2,7 @@ name: Star repositories
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1"
 
   workflow_dispatch:
 


### PR DESCRIPTION
The workflow for adding stars to the repository can be triggered at a slower pace, let's say once a week, on Monday.